### PR TITLE
Select pads properly

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,6 @@
 window.addEventListener('load', ()=>{
   const sounds=document.querySelectorAll(".sound");
-  const pads=document.querySelectorAll(".pads div");
+  const pads=document.querySelectorAll(".pads div div");
 
   if('serviceWorker' in navigator){
     try {


### PR DESCRIPTION
The previous selector selects all divs under .pads which creates an error.